### PR TITLE
Make compatible with Laravel 5. Read and write key from .env file.

### DIFF
--- a/src/TinyGenerateCommand.php
+++ b/src/TinyGenerateCommand.php
@@ -19,16 +19,22 @@ class TinyGenerateCommand extends Command
 
     public function fire()
     {
-        list($path, $contents) = $this->getKeyFile();
-
         $key = Tiny::generate_set();
+        
+        $path = base_path('.env');
 
-        $contents = str_replace($this->laravel['config']['league/tiny::key'], $key, $contents);
-
-        $this->files->put($path, $contents);
-
-        $this->laravel['config']['league/tiny::key'] = $key;
-
+        if (file_exists($path) && getenv('LEAGUE_TINY_KEY') !== false) {
+            //Already set, so replace it.
+            file_put_contents($path, str_replace(
+                'LEAGUE_TINY_KEY='.getenv('LEAGUE_TINY_KEY'), 'LEAGUE_TINY_KEY='.$key, file_get_contents($path)
+            ));   
+        } else {
+            //Append it to the bottom
+            $fp = fopen($path, 'a');
+            fwrite($fp, "\nLEAGUE_TINY_KEY=$key\n");
+            fclose($fp);
+        }
+        
         $this->info("Tiny key [$key] has been set.");
     }
 

--- a/src/TinyGenerateCommand.php
+++ b/src/TinyGenerateCommand.php
@@ -35,9 +35,7 @@ class TinyGenerateCommand extends Command
 
             if (file_exists($path) && getenv('LEAGUE_TINY_KEY') !== false) {
                 //Already set, so replace it.
-                file_put_contents($path, str_replace(
-                    'LEAGUE_TINY_KEY='.getenv('LEAGUE_TINY_KEY'), 'LEAGUE_TINY_KEY='.$key, file_get_contents($path)
-                ));
+                file_put_contents($path, str_replace('LEAGUE_TINY_KEY='.getenv('LEAGUE_TINY_KEY'), 'LEAGUE_TINY_KEY='.$key, file_get_contents($path)));
             } else {
                 //Append it to the bottom
                 $fp = fopen($path, 'a');

--- a/src/TinyGenerateCommand.php
+++ b/src/TinyGenerateCommand.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Application;
 
 class TinyGenerateCommand extends Command
 {
@@ -21,20 +22,41 @@ class TinyGenerateCommand extends Command
     {
         $key = Tiny::generate_set();
         
-        $path = base_path('.env');
+        //Parse Laravel Version
+        $pattern = '/(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<hotfix>\d+))/';
 
-        if (file_exists($path) && getenv('LEAGUE_TINY_KEY') !== false) {
-            //Already set, so replace it.
-            file_put_contents($path, str_replace(
-                'LEAGUE_TINY_KEY='.getenv('LEAGUE_TINY_KEY'), 'LEAGUE_TINY_KEY='.$key, file_get_contents($path)
-            ));   
-        } else {
-            //Append it to the bottom
-            $fp = fopen($path, 'a');
-            fwrite($fp, "\nLEAGUE_TINY_KEY=$key\n");
-            fclose($fp);
+        if (!preg_match($pattern, Application::VERSION, $version)) {
+            $this->warning('Could not detect a version of Laravel. Pre-Laravel 5 behaviour assumed. Writing Key to config file.');
         }
-        
+
+        if (is_array($version) && $version['major'] >= '5') {
+            //Laravel 5 integrates vlucas' dotenv, so store key in .ENV file.
+            $path = base_path('.env');
+
+            if (file_exists($path) && getenv('LEAGUE_TINY_KEY') !== false) {
+                //Already set, so replace it.
+                file_put_contents($path, str_replace(
+                    'LEAGUE_TINY_KEY='.getenv('LEAGUE_TINY_KEY'), 'LEAGUE_TINY_KEY='.$key, file_get_contents($path)
+                ));
+            } else {
+                //Append it to the bottom
+                $fp = fopen($path, 'a');
+                fwrite($fp, "\nLEAGUE_TINY_KEY=$key\n");
+                fclose($fp);
+            }
+
+        } else {
+            //If Version 4, or default, store file in config file, as per before.
+            list($path, $contents) = $this->getKeyFile();
+
+            $contents = str_replace($this->laravel['config']['league/tiny::key'], $key, $contents);
+            
+            $this->files->put($path, $contents);
+
+            $this->laravel['config']['league/tiny::key'] = $key;
+
+        } 
+
         $this->info("Tiny key [$key] has been set.");
     }
 

--- a/src/TinyServiceProvider.php
+++ b/src/TinyServiceProvider.php
@@ -1,6 +1,7 @@
 <?php namespace League\Tiny;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Foundation\Application;
 
 class TinyServiceProvider extends ServiceProvider
 {
@@ -17,7 +18,19 @@ class TinyServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app['tiny'] = $this->app->share(function ($app) {
-            $key = getenv('LEAGUE_TINY_KEY');
+
+            //Parse Laravel Version
+            $pattern = '/(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<hotfix>\d+))/';
+
+            if (!preg_match($pattern, Application::VERSION, $version)) {
+                $this->warning('Could not detect a version of Laravel. Pre-Laravel 5 behaviour assumed. Writing Key to config file.');
+            }
+
+            if (is_array($version) && $version['major'] >= '5') {
+                $key = getenv('LEAGUE_TINY_KEY');
+            } else {
+                $key = $app['config']['league/tiny::key'];
+            }
 
             return new Tiny($key);
         });

--- a/src/TinyServiceProvider.php
+++ b/src/TinyServiceProvider.php
@@ -7,8 +7,6 @@ class TinyServiceProvider extends ServiceProvider
 
     public function boot()
     {
-        $this->package('league/tiny', 'league/tiny', __DIR__ . '/../');
-
         $this->app['tiny.generate'] = $this->app->share(function ($app) {
             return new TinyGenerateCommand($app['files']);
         });
@@ -19,7 +17,7 @@ class TinyServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app['tiny'] = $this->app->share(function ($app) {
-            $key = $app['config']['league/tiny::key'];
+            $key = getenv('LEAGUE_TINY_KEY');
 
             return new Tiny($key);
         });


### PR DESCRIPTION
Hey mate,

I've just set up storage for the Tiny key in the .env file, as per Laravel 5.

I realised that there might be some people still using Laravel 4 for whom this might break, so maybe there should be a couple of if statements around the place?

Anyway, do with it as you will.