### PR TITLE
Laravel 5 support for Tiny-PHP

### DIFF
--- a/src/ZackKitzmiller/Laravel5/TinyGenerateCommand.php
+++ b/src/ZackKitzmiller/Laravel5/TinyGenerateCommand.php
@@ -1,5 +1,6 @@
 <?php namespace ZackKitzmiller\Laravel5;
 
+use ZackKitzmiller\Tiny;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 

--- a/src/ZackKitzmiller/Laravel5/TinyGenerateCommand.php
+++ b/src/ZackKitzmiller/Laravel5/TinyGenerateCommand.php
@@ -1,0 +1,32 @@
+<?php namespace ZackKitzmiller\Laravel5;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+
+class TinyGenerateCommand extends Command {
+
+    protected $name = 'tiny:generate';
+
+    protected $description = "Generate a valid key";
+
+    public function fire()
+    {
+        $key = Tiny::generate_set();
+
+        $path = base_path('.env');
+
+        if (file_exists($path) and getenv('LEAGUE_TINY_KEY') !== false) {
+            $originalContent = file_get_contents($path);
+            $content = str_replace('LEAGUE_TINY_KEY='.getenv('LEAGUE_TINY_KEY'), 'LEAGUE_TINY_KEY='.$key, $originalContent);
+
+            file_put_contents($path, $content);
+        } else {
+            $fp = fopen($path, 'a');
+            fwrite($fp, "\nLEAGUE_TINY_KEY=$key\n");
+            fclose($fp);
+        }
+
+        $this->info("Tiny key [$key] has been set.");
+    }
+
+}

--- a/src/ZackKitzmiller/Laravel5/TinyServiceProvider.php
+++ b/src/ZackKitzmiller/Laravel5/TinyServiceProvider.php
@@ -1,5 +1,6 @@
 <?php namespace ZackKitzmiller\Laravel5;
 
+use ZackKitzmiller\Tiny;
 use Illuminate\Support\ServiceProvider;
 
 class TinyServiceProvider extends ServiceProvider

--- a/src/ZackKitzmiller/Laravel5/TinyServiceProvider.php
+++ b/src/ZackKitzmiller/Laravel5/TinyServiceProvider.php
@@ -1,0 +1,29 @@
+<?php namespace ZackKitzmiller\Laravel5;
+
+use Illuminate\Support\ServiceProvider;
+
+class TinyServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        $this->app['tiny.generate'] = $this->app->share(function ($app) {
+            return new TinyGenerateCommand();
+        });
+
+        $this->commands('tiny.generate');
+    }
+
+    public function register()
+    {
+        $this->app['tiny'] = $this->app->share(function ($app) {
+            $key = getenv('LEAGUE_TINY_KEY');
+
+            return new Tiny($key);
+        });
+    }
+
+    public function provides()
+    {
+        return array('tiny');
+    }
+}


### PR DESCRIPTION
I've added the additional folder `Laravel5` to provide non breaking changes to the Laravel 4 Service Provider and command. 

Not sure if you'd like to tackle this another way though?  
