### PR TITLE
Remove use of depracated share method in Laravel 5 service provider

### DIFF
--- a/src/ZackKitzmiller/Laravel5/TinyServiceProvider.php
+++ b/src/ZackKitzmiller/Laravel5/TinyServiceProvider.php
@@ -7,7 +7,7 @@ class TinyServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        $this->app['tiny.generate'] = $this->app->share(function ($app) {
+        $this->app->singleton('tiny.generate', function () {
             return new TinyGenerateCommand();
         });
 
@@ -16,7 +16,7 @@ class TinyServiceProvider extends ServiceProvider
 
     public function register()
     {
-        $this->app['tiny'] = $this->app->share(function ($app) {
+        $this->app->singleton('tiny', function () {
             $key = getenv('LEAGUE_TINY_KEY');
 
             return new Tiny($key);


### PR DESCRIPTION
Use of the `share` method for registering singletons has been deprecated in Laravel 5.4 in favour of the `singleton` method.

This PR replaces use of the `share` method in the Laravel 5 service provider.